### PR TITLE
Remove the usage of the static Current variable which are unnecessary 

### DIFF
--- a/src/UmbracoContentApi/UmbracoContentApi.Web/Controllers/AssetApiController.cs
+++ b/src/UmbracoContentApi/UmbracoContentApi.Web/Controllers/AssetApiController.cs
@@ -2,8 +2,6 @@
 using System.Web.Http;
 using System.Web.Http.Description;
 using Umbraco.Core.Models.PublishedContent;
-using Umbraco.Web;
-using Umbraco.Web.Composing;
 using Umbraco.Web.WebApi;
 using UmbracoContentApi.Core.Models;
 using UmbracoContentApi.Core.Resolvers;
@@ -14,20 +12,19 @@ namespace UmbracoContentApi.Web.Controllers
     public class AssetApiController : UmbracoApiController
     {
         private readonly IMediaResolver _mediaResolver;
-        private readonly UmbracoHelper _umbracoHelper;
-
+        
         public AssetApiController(
             IMediaResolver mediaResolver)
         {
             _mediaResolver = mediaResolver;
-            _umbracoHelper = Current.UmbracoHelper;
+
         }
 
         [Route("{id:guid}")]
         [ResponseType(typeof(ContentModel))]
         public IHttpActionResult Get(Guid id)
         {
-            IPublishedContent media = _umbracoHelper.Media(id);
+            IPublishedContent media = Umbraco.Media(id);
             AssetModel mediaModel = _mediaResolver.ResolveMedia(media);
 
             return Ok(mediaModel);

--- a/src/UmbracoContentApi/UmbracoContentApi.Web/Controllers/ContentApiController.cs
+++ b/src/UmbracoContentApi/UmbracoContentApi.Web/Controllers/ContentApiController.cs
@@ -2,8 +2,6 @@
 using System.Web.Http;
 using System.Web.Http.Description;
 using Umbraco.Core.Models.PublishedContent;
-using Umbraco.Web;
-using Umbraco.Web.Composing;
 using Umbraco.Web.WebApi;
 using UmbracoContentApi.Core.Resolvers;
 using UmbracoContentApi.Core.Models;
@@ -15,20 +13,18 @@ namespace UmbracoContentApi.Web.Controllers
     {
         private readonly Lazy<IContentResolver> _contentResolver;
         private readonly IVariationContextAccessor _variationContextAccessor;
-        private readonly UmbracoHelper _umbracoHelper;
 
         public ContentApiController(Lazy<IContentResolver> contentResolver, IVariationContextAccessor variationContextAccessor)
         {
             _contentResolver = contentResolver;
             _variationContextAccessor = variationContextAccessor;
-            _umbracoHelper = Current.UmbracoHelper;
         }
 
         [Route("{id:guid}")]
         [ResponseType(typeof(ContentModel))]
         public IHttpActionResult Get(Guid id)
         { 
-            IPublishedContent content = _umbracoHelper.Content(id);
+            IPublishedContent content = Umbraco.Content(id);
             var model = _contentResolver.Value.ResolveContent(content);
             return Ok(model);
         }

--- a/src/UmbracoContentApi/UmbracoContentApi.Web/Controllers/PreviewApiController.cs
+++ b/src/UmbracoContentApi/UmbracoContentApi.Web/Controllers/PreviewApiController.cs
@@ -3,8 +3,6 @@ using System.Web.Http;
 using System.Web.Http.Description;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Services;
-using Umbraco.Web;
-using Umbraco.Web.Composing;
 using Umbraco.Web.PublishedCache;
 using Umbraco.Web.WebApi;
 using UmbracoContentApi.Core.Models;
@@ -16,7 +14,6 @@ namespace UmbracoContentApi.Web.Controllers
     public class PreviewApiController : UmbracoApiController
     {
         private readonly Lazy<IContentResolver> _contentResolver;
-        private readonly UmbracoHelper _umbracoHelper;
         private readonly IPublishedSnapshotService _publishedSnapshotService;
         private readonly IUserService _userService;
         private readonly IContentService _contentService;
@@ -27,7 +24,6 @@ namespace UmbracoContentApi.Web.Controllers
             _publishedSnapshotService = publishedSnapshotService;
             _userService = userService;
             _contentService = contentService;
-            _umbracoHelper = Current.UmbracoHelper;
         }
 
         [Route("{id:guid}")]
@@ -36,7 +32,7 @@ namespace UmbracoContentApi.Web.Controllers
         {
             var val = _publishedSnapshotService.EnterPreview(_userService.GetUserById(-1), _contentService.GetById(id).Id);
 
-            IPublishedContent content = _umbracoHelper.Content(id);
+            IPublishedContent content = Umbraco.Content(id);
 
             ContentModel contentModel = _contentResolver.Value.ResolveContent(content);
 


### PR DESCRIPTION
Uh oh, `Current` detected! 🙈 

https://github.com/deMD/UmbracoContentApi/blob/df9e96e5e5732c56df9c7ba4bb6857c51f362060/src/UmbracoContentApi/UmbracoContentApi.Web/Controllers/ContentApiController.cs#L24

If you can avoid it, then never get anything from Current, in this case you are already inheriting from `UmbracoApiController` so you have all you need. 👍